### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,27 @@
 </p> 
 
 ## Hex Colors Codes 
-| Color  | Hex Code |   
-| :--- | :---: |  
-| s:uwufg_gui | #c5c8c9 |   
-| s:uwubg_gui | #131A1C | 
-| s:uwu0_gui | #1b2224 | 
-| s:uwu1_gui | #e74c4c | 
-| s:uwu2_gui | #6bb05d  | 
-| s:uwu3_gui | #e59e67  | 
-| s:uwu4_gui | #53A7BF  | 
-| s:uwu5_gui | #CD69CC  | 
-| s:uwu6_gui | #51a39f  | 
-| s:uwu7_gui | #bcbcbc  | 
-| s:uwu8_gui | #454c4e  | 
-| s:uwu9_gui | #c26f6f  |
-| s:uwu10_gui | #8dc776   | 
-| s:uwu11_gui | #e7ac7e  | 
-| s:uwu12_gui | #6CBAD1  | 
-| s:uwu13_gui | #E182E0  | 
-| s:uwu14_gui | #6db0ad  | 
-| s:uwu15_gui | #bfbfbf  | 
+| Color          | Hex Code |   
+| :------------  | :------: |  
+| Foreground     | #c5c8c9  |   
+| Background     | #131a1c  | 
+| Black          | #1b2224  | 
+| Red            | #e74c4c  | 
+| Green          | #6bb05d  | 
+| Yellow         | #e59e67  | 
+| Blue           | #53a7bf  | 
+| Magenta        | #cd69cc  | 
+| Cyan           | #51a39f  | 
+| White          | #c4c4c4  | 
+| Bright Black   | #454c4e  | 
+| Bright Red     | #c26f6f  |
+| Bright Green   | #8dc776  | 
+| Bright Yellow  | #e7ac7e  | 
+| Bright Blue    | #6cbad1  | 
+| Bright Magenta | #e182e0  | 
+| Bright Cyan    | #6db0ad  | 
+| Bright White   | #cecece  | 
+
 
 ## Terminal Config
 - <a href="https://github.com/mangeshrex/uwu.vim/tree/main/assets/alacritty.yml">Alacritty</a>


### PR DESCRIPTION
I have updated the color names to make them more readable and the white and bright white color in readme to match assets/alacritty.yml
however I have left black/bright black and magenta/bright magenta as the same in the old readme


It's a little hard to tell which one is brighter in the newer megenta:
![image](https://user-images.githubusercontent.com/50115012/143633193-abf64784-dacd-4eec-b8f0-40e25904ffa4.png)

where as it's much easier to tell which one is brighter in the older version of the magenta colors:
![image](https://user-images.githubusercontent.com/50115012/143634001-1dca97a1-b9d2-4143-a7bd-f06f0fef0c19.png)

When I was fixing the readme, I noticed that the black/bright black color hex code in the readme are different from the hex codes in assets/alacritty.yml, so I just left the black color hex codes as it is in the old readme.

I have also noticed that the bright and normal colors in assets/alacritty.yml are flipped. By looking at the hex codes in that file, you can clearly see that the normal colors are brighter. Is this intentional? 